### PR TITLE
Use gatt.connect instead of connectGATT

### DIFF
--- a/main.js
+++ b/main.js
@@ -186,7 +186,7 @@
 		})
 		.then(device => {
 			console.log('Got device: ' + device.name);
-			return device.connectGATT();
+			return device.gatt.connect();
 		})
 		.then(server => {
 			console.log('Got server');


### PR DESCRIPTION
How about use gatt.connect instead of connectGATT?
It was no longer being used in official documents.

And this my change is already merged to Chrome sample, please refer this PR.
https://github.com/GoogleChrome/samples/pull/314
